### PR TITLE
Remove setCategory and fix missing resolve

### DIFF
--- a/index.js
+++ b/index.js
@@ -43,6 +43,7 @@ class RCTGoogleSpeechApi {
     }
     return new Promise((resolve, reject) => {
       RNGoogleSpeechApi.startSpeech(locale);
+      resolve();
     });
   }
   stop() {
@@ -59,6 +60,7 @@ class RCTGoogleSpeechApi {
   cancel() {
     return new Promise((resolve, reject) => {
       RNGoogleSpeechApi.cancelSpeech();
+      resolve();
     });
   }
   isAvailable() {

--- a/ios/AudioController.m
+++ b/ios/AudioController.m
@@ -126,8 +126,6 @@ static OSStatus playbackCallback(void *inRefCon,
   AVAudioSession *session = [AVAudioSession sharedInstance];
 
   NSError *error;
-  BOOL ok = [session setCategory:AVAudioSessionCategoryPlayAndRecord error:&error];
-  NSLog(@"set category %d", ok);
 
   // This doesn't seem to really indicate a problem (iPhone 6s Plus)
 #ifdef IGNORE

--- a/ios/RNGoogleSpeechApi.m
+++ b/ios/RNGoogleSpeechApi.m
@@ -1,3 +1,5 @@
+// DO NOT something to effect to global AVAudioSession like setCategory.
+// It is highly recommended to do this in JS to avoid conflict with other native modules.
 
 #import <AVFoundation/AVFoundation.h>
 
@@ -26,9 +28,6 @@ RCT_EXPORT_MODULE();
 }
 
 - (void) recordAudio {
-    AVAudioSession *audioSession = [AVAudioSession sharedInstance];
-    [audioSession setCategory:AVAudioSessionCategoryPlayAndRecord error:nil];
-    
     _audioData = [[NSMutableData alloc] init];
     [[AudioController sharedInstance] prepareWithSampleRate:SAMPLE_RATE];
     [[SpeechRecognitionService sharedInstance] setSampleRate:SAMPLE_RATE];


### PR DESCRIPTION
* Do not something to effect to global AVAudioSession like setCategory.
* It is highly recommended to do this in JS to avoid conflict with other native modules.
* In our case, let's depend on the react-native-sound's `AVAudioSession` only.